### PR TITLE
WIP: Update Soot Dependency

### DIFF
--- a/boomerangScope/pom.xml
+++ b/boomerangScope/pom.xml
@@ -14,7 +14,7 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
-      <groupId>ca.mcgill.sable</groupId>
+      <groupId>org.soot-oss</groupId>
       <artifactId>soot</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     </modules>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <sootVersion>4.1.0-SNAPSHOT</sootVersion>
+        <sootVersion>4.3.0-SNAPSHOT</sootVersion>
         <fmt-maven-plugin.version>2.9</fmt-maven-plugin.version>
         <maven-scm-plugin.version>1.11.2</maven-scm-plugin.version>
         <enforced-maven-version>3.6.1</enforced-maven-version>
@@ -169,9 +169,9 @@
                 <version>1.0.0</version>
             </dependency>
             <dependency>
-                <groupId>ca.mcgill.sable</groupId>
+                <groupId>org.soot-oss</groupId>
                 <artifactId>soot</artifactId>
-                <version>4.1.0</version>
+                <version>${sootVersion}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/testCore/pom.xml
+++ b/testCore/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>testCore</artifactId>
     <dependencies>
         <dependency>
-            <groupId>ca.mcgill.sable</groupId>
+            <groupId>org.soot-oss</groupId>
             <artifactId>soot</artifactId>
         </dependency>
         <dependency>

--- a/testCore/src/main/java/test/core/selfrunning/AbstractTestingFramework.java
+++ b/testCore/src/main/java/test/core/selfrunning/AbstractTestingFramework.java
@@ -100,14 +100,6 @@ public abstract class AbstractTestingFramework {
     Options.v().setPhaseOption("cg.spark", "verbose:true");
     Options.v().set_output_format(Options.output_format_none);
 
-    String userdir = System.getProperty("user.dir");
-    String sootCp = userdir + "/target/test-classes";
-    String javaHome = System.getProperty("java.home");
-    if (javaHome == null || javaHome.equals(""))
-      throw new RuntimeException("Could not get property java.home!");
-    sootCp += File.pathSeparator + javaHome + "/lib/rt.jar";
-    sootCp += File.pathSeparator + javaHome + "/lib/jce.jar";
-
     Options.v().set_no_bodies_for_excluded(true);
     Options.v().set_allow_phantom_refs(true);
 
@@ -116,7 +108,17 @@ public abstract class AbstractTestingFramework {
     Options.v().setPhaseOption("jb", "use-original-names:true");
 
     Options.v().set_exclude(excludedPackages());
-    Options.v().set_soot_classpath(getSootClassPath());
+
+    // JAVA VERSION 8
+    if(getJavaVersion() < 9) {
+      Options.v().set_prepend_classpath(true);
+      Options.v().set_soot_classpath(getSootClassPath());
+    }
+    // JAVA VERSION 9
+    else if(getJavaVersion() >= 9) {
+      Options.v().set_soot_classpath("VIRTUAL_FS_FOR_JDK" + File.pathSeparator + getSootClassPath());
+    }
+
     // Options.v().set_main_class(this.getTargetClass());
     SootClass sootTestCaseClass = Scene.v().forceResolve(getTestCaseClassName(), SootClass.BODIES);
 
@@ -159,8 +161,10 @@ public abstract class AbstractTestingFramework {
       throw new RuntimeException("Could not get property java.home!");
 
     String sootCp = userdir + "/target/test-classes";
-    sootCp += File.pathSeparator + javaHome + "/lib/rt.jar";
-    sootCp += File.pathSeparator + javaHome + "/lib/jce.jar";
+    if(getJavaVersion() < 9) {
+      sootCp += File.pathSeparator + javaHome + "/lib/rt.jar";
+      sootCp += File.pathSeparator + javaHome + "/lib/jce.jar";
+    }
     return sootCp;
   }
 
@@ -232,5 +236,15 @@ public abstract class AbstractTestingFramework {
    */
   protected boolean staticallyUnknown() {
     return true;
+  }
+
+  private static int getJavaVersion() {
+    String version = System.getProperty("java.version");
+    if(version.startsWith("1.")) {
+      version = version.substring(2, 3);
+    } else {
+      int dot = version.indexOf(".");
+      if(dot != -1) { version = version.substring(0, dot); }
+    } return Integer.parseInt(version);
   }
 }


### PR DESCRIPTION
- Fixes issue #7 
- Make tests run for Java >= 9

**IMPORTANT:**

 For some reason **`VectorTest`** (`test2`, `test4`, `test5`, `test6`) fails on Java >= 9 with message:  
```
java.lang.RuntimeException: Unsound results: [MustBe [s (typestate.tests.VectorTest.<typestate.tests.VectorTest: void test2()>) @ mustBeInAcceptingState(s) in state ACCEPTING]]

	at test.IDEALTestingFramework.analyze(IDEALTestingFramework.java:167)
	at test.IDEALTestingFramework$2.internalTransform(IDEALTestingFramework.java:134)
	at soot.SceneTransformer.transform(SceneTransformer.java:36)
	at soot.Transform.apply(Transform.java:102)
	at soot.ScenePack.internalApply(ScenePack.java:35)
	at soot.Pack.apply(Pack.java:117)
	at test.core.selfrunning.AbstractTestingFramework.analyze(AbstractTestingFramework.java:85)
	at test.core.selfrunning.AbstractTestingFramework.beforeTestCaseExecution(AbstractTestingFramework.java:40)
```
This error also happens in the `CROSSING/SPDS` repo!

Tested with Java 11.0.7 and soot 4.2.1 and soot 4.3.0-SNPSHT