### PR TITLE
Add components for deployment to Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,30 +7,17 @@ Additionally, it contains an implementation of [Boomerang](boomerangPDS) and [ID
 
 # Use as Maven dependency
 
-All projects inside this repository are pushed to GitHub's Maven repository for every release.
-
-To include a dependency from this repository to your poject, you first have to add the repository to your pom file:
-
+The projects are released on [Maven Central](https://central.sonatype.com/artifact/de.fraunhofer.iem/SPDS) and can be included as a dependency in `.pom` files:
 
 ```.xml
 <dependencies>
   <dependency>
     <groupId>de.fraunhofer.iem</groupId>
-    <artifactId>WPDS</artifactId>
-    <version>3.1.1</version>
+    <artifactId>SPDS</artifactId>
+    <version>3.1.2</version>
   </dependency>
 </dependencies>
-<repositories>
-  <repository>
-      <id>github</id>
-      <url>https://maven.pkg.github.com/CodeShield-Security/SPDS/</url>
-  </repository>
-</repositories>	
 ```
-
-To access the GitHub packages repository, you also need to set up GitHub credentials in your Maven's `settings.xml` file. Therefore, you need to add a `server` block with the id `github`, your username and an access token that has `package:read` rights to your `setting.xml`.
-An in-depth documentation on how to do this can be found [here](https://docs.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-apache-maven-for-use-with-github-packages#authenticating-to-github-packages). 
-
 
 # Checkout, Build and Install
 

--- a/SynchronizedPDS/pom.xml
+++ b/SynchronizedPDS/pom.xml
@@ -30,7 +30,7 @@
         </dependency>
         <dependency>
             <groupId>de.fraunhofer.iem</groupId>
-            <artifactId>PathExpression</artifactId>
+            <artifactId>pathexpression</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/WPDS/pom.xml
+++ b/WPDS/pom.xml
@@ -18,7 +18,7 @@
         </dependency>
         <dependency>
             <groupId>de.fraunhofer.iem</groupId>
-            <artifactId>PathExpression</artifactId>
+            <artifactId>pathexpression</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,8 @@
     <version>3.1.2</version>
     <packaging>pom</packaging>
     <name>SPDS</name>
+    <description>Synchronized Pushdown Systems for Pointer and Data-Flow Analysis</description>
+    <url>https://github.com/CodeShield-Security/SPDS</url>
 
     <licenses>
         <license>
@@ -165,8 +167,8 @@
             </dependency>
             <dependency>
                 <groupId>de.fraunhofer.iem</groupId>
-                <artifactId>PathExpression</artifactId>
-                <version>1.0.0</version>
+                <artifactId>pathexpression</artifactId>
+                <version>1.0.2</version>
             </dependency>
             <dependency>
                 <groupId>org.soot-oss</groupId>
@@ -207,26 +209,16 @@
     </dependencyManagement>
 
     <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+        </snapshotRepository>
         <repository>
-            <id>github</id>
-            <name>GitHub CodeShield-Security Apache Maven Packages</name>
-            <url>https://maven.pkg.github.com/CodeShield-Security/SPDS/</url>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 
-    <repositories>
-        <repository>
-            <id>sonatype-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository>
-        <repository>
-            <id>swt</id>
-            <url>https://soot-build.cs.uni-paderborn.de/nexus/repository/swt-upb/</url>
-        </repository>
-    </repositories>
     <profiles>
         <profile>
             <id>ci</id>
@@ -239,6 +231,54 @@
                         <configuration>
                             <!-- pretty sure this has to work nicer. dont wanna waste more time into it, though -->
                             <skip>${skipFormatPlugin}</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!-- This profile is used to avoid running the deployment in non-deployment
+            contexts because they require specific keys from the Github remote. Include
+            this profile by setting the -Pdeployment flag. -->
+        <profile>
+            <id>deployment</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.0.1</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-release-plugin</artifactId>
+                        <version>3.0.1</version>
+                        <configuration>
+                            <tagNameFormat>@{project.version}</tagNameFormat>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.13</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://s01.oss.sonatype.org</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Components for Deployment on Maven Central:
- Repository in `<distributionManagement>` has to be Maven Central (the Nexus server does not exist anymore)
- Profile that contains the relevant plugins for deployment (use `-Pdeployment`)
- Update README: Remoe the GitHub package manager
- The deploy action is already there